### PR TITLE
V. 0.1.0

### DIFF
--- a/installationdocs/IF_installation.xml
+++ b/installationdocs/IF_installation.xml
@@ -1,16 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
-<profile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="profile.xsd" useForConfiguration="1" base="base"
-  infoUrl="http://providence.collectiveaccess.org/wiki/DefaultProfile">
+<?xml version='1.0' encoding='utf-8'?>
+<profile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="profile.xsd" useForConfiguration="1" base="base" infoUrl="http://providence.collectiveaccess.org/wiki/DefaultProfile">
   <profileName>IF Custom Profile</profileName>
   <profileDescription>If Custom Profile</profileDescription>
   <locales>
     <locale lang="en" country="US">English</locale>
     <locale lang="fr" country="FR">Français</locale>
   </locales>
-  <!-- Lists-->
+  
   <lists>
-    <!-- Default Lists-->
+    
 
     <list code="aat_vocabulary" hierarchical="1" system="0" vocabulary="1">
       <labels>
@@ -1290,9 +1288,9 @@
     </list>
 
 
-    <!-- IF Custom Lists-->
+    
 
-    <!-- 01_Languages -->
+    
 
     <list code="languageslist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -2392,7 +2390,7 @@
       </items>
     </list>
 
-    <!-- 02_Themes -->
+    
 
     <list code="themeslist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -2645,7 +2643,7 @@
     </list>
 
 
-    <!-- 03_Cultural Context -->
+    
 
     <list code="cultcontlist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -2906,7 +2904,7 @@
     </list>
 
 
-    <!-- 04_Social Groups-->
+    
 
     <list code="socialgrouplist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -3222,7 +3220,7 @@
       </items>
     </list>
 
-    <!-- 05_Licences -->
+    
 
     <list code="licencelist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -3314,7 +3312,7 @@
       </items>
     </list>
 
-    <!-- 06_Gender -->
+    
 
     <list code="genderl" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -3358,7 +3356,7 @@
       </items>
     </list>
 
-    <!-- 07_Cultural Sensitivity -->
+    
 
     <list code="cultsenslist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -3407,7 +3405,7 @@
     </list>
 
 
-    <!-- 08_Occupations-->
+    
 
     <list code="occupationsl" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -3939,7 +3937,7 @@
       </items>
     </list>
 
-    <!-- 09_Project Types-->
+    
 
     <list code="prjtypelist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -3991,7 +3989,7 @@
       </items>
     </list>
 
-    <!-- 10_Project Regions-->
+    
 
     <list code="prjregionlist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -4052,7 +4050,7 @@
     </list>
 
 
-    <!-- 11_Rights Statement-->
+    
 
     <list code="rightsstatelist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -4220,7 +4218,7 @@
     </list>
 
 
-    <!-- 12_Roles-->
+    
 
     <list code="roleslist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -4288,7 +4286,7 @@
       </items>
     </list>
 
-    <!-- 13_Language Types-->
+    
 
     <list code="langlabellist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -4316,7 +4314,7 @@
       </items>
     </list>
 
-    <!-- 14_Authority Sources-->
+    
 
     <list code="authoritylist" hierarchical="0" system="0" vocabulary="1">
       <labels>
@@ -4367,23 +4365,14 @@
 
 
   <elementSets>
-    <!-- Resources -->
+    
     <metadataElement code="idno" datatype="Text">
       <labels>
         <label locale="en_US">
           <name>Unique Record Identifier</name>
           <description>An alphanumeric identifier for the record created for the IF
                     Repository.</description>
-          <entry>String-CV. Derived from Projects ID</entry>
-          <dcequivalent>dc:identifier</dcequivalent>
-          <repeatable>No</repeatable>
-          <modality>Mandatory</modality>
-          <guideline>The PIs of each project will receive a pre-assigned unique project
-                    identifier.
-                    Unique
-                    ID's derivered from that ID and adding 4 digit secuential numbers.</guideline>
-          <example>UFC00800001</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -4426,21 +4415,7 @@
           <description>Shows the parent collection or object which this record related
                     to/part
                     of.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>No</repeatable>
-          <modality>Optional</modality>
-          <guideline>International or local identifiers associated with the original
-                    material.</guideline>
-          <example>CO 1/25 (National Archives Reference), 309.6 P.97 (Dewey Classification
-                    Number),
-                    AGN
-                    COL CI Folder 75, Document 2 (ISADG classification), 2019SG07-0239 (Unique
-                    ID of
-                    a
-                    digital
-                    collection)</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -4467,14 +4442,7 @@
           <description>Shows the parent collection or object which this record related
                     to/part
                     of.</description>
-          <entry>String-CV (Projects)</entry>
-          <dcequivalent>dc:isPartOf</dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Mandatory</modality>
-          <guideline>Provide the name of the project as it is on the "Projects" sheet.</guideline>
-          <example>Vernacular Songs as Archives and Modes of Social Redress in Jamestown,
-                    Accra</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -4500,18 +4468,7 @@
           <name>Resource Title Preferred</name>
           <description>The name given to the resource by the Creator (depositor) in any
                     language.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent>dc:title</dcequivalent>
-          <repeatable>No</repeatable>
-          <modality>Mandatory</modality>
-          <guideline>Provide a short title for the resource in any language. Do not use
-                    any
-                    punctuation.
-                    Only capitalize the first alphabet of the project title, acronyms and any
-                    personal and
-                    geographic names.</guideline>
-          <example>Aso wiwo awon obinrin ile Yoruba</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -4536,15 +4493,7 @@
           <name>Resource Title Alternative</name>
           <description>The name given to the resource by the Creator (depositor) in other
                     language.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent>dc:alternative</dcequivalent>
-          <repeatable>No</repeatable>
-          <modality>Optional</modality>
-          <guideline>Provide a translation or modified version of the title attributed to
-                    the
-                    record.</guideline>
-          <example>Local-made cloth of a typical Ghanian lady</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -4568,13 +4517,7 @@
         <label locale="en_US">
           <name>External Link</name>
           <description>Name and the url of the website where this resource was published.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline></guideline>
-          <example></example>
-        </label>
+          </label>
       </labels>
       <elements>
         <metadataElement code="exlink_name" datatype="Text">
@@ -4582,13 +4525,7 @@
             <label locale="en_US">
               <name>External Link Website Name</name>
               <description>Name of the website where this resource was published.</description>
-              <entry>String-Free text</entry>
-              <dcequivalent></dcequivalent>
-              <repeatable>Yes</repeatable>
-              <modality>Optional</modality>
-              <guideline></guideline>
-              <example></example>
-            </label>
+              </label>
           </labels>
           <settings>
             <setting name="fieldWidth">40</setting>
@@ -4600,13 +4537,7 @@
             <label locale="en_US">
               <name>External Link Website URL</name>
               <description>URL of the website where this resource was published.</description>
-              <entry>String-Free text</entry>
-              <dcequivalent>dc:source</dcequivalent>
-              <repeatable>No</repeatable>
-              <modality>Optional</modality>
-              <guideline></guideline>
-              <example></example>
-            </label>
+              </label>
           </labels>
           <settings>
             <setting name="fieldWidth">40</setting>
@@ -4636,23 +4567,10 @@
                     connected
                     to the
                     resource. Content descriptions in the case of visual resources.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent>dc:description</dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Strongly Suggested</modality>
-          <guideline>Provide textual description of the resource in English limited to
-                    maximum
-                    of
-                    three concise sentences. Include important keywords related to the
-                    significance
-                    of the
-                    resource. Since the description field is a potentially rich source of
-                    indexable
-                    vocabulary, care should be taken to provide this element when possible.</guideline>
-          <example>Ile alo ti awon omode eya Arika lo ni odun to ti pe</example>
-        </label>
+          </label>
       </labels>
       <settings>
+        <setting name="usewysiwygeditor">1</setting>
         <setting name="fieldWidth">90</setting>
         <setting name="fieldHeight">3</setting>
         <setting name="minChars">0</setting>
@@ -4687,23 +4605,7 @@
                     descriptions
                     in the
                     case of visual resources.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent>dc:description</dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Provide textual description of the resource in other language limited
-                    to
-                    maximum
-                    of three concise sentences. Include important keywords related to the
-                    significance of
-                    the resource. Since the description field is a potentially rich source of
-                    indexable
-                    vocabulary, care should be taken to provide this element when possible.</guideline>
-          <example>Story book used for play by Pandalong children to understand the
-                    direction
-                    of the
-                    moon and sun. Created between 1908 and 1910.</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -4742,16 +4644,7 @@
               <description>The primary language spoken by the participant (if video or
                             audio resource). The
                             primary language written on the image or in the document.</description>
-              <entry>String-CV (Language)</entry>
-              <dcequivalent>dc:language</dcequivalent>
-              <repeatable>Yes</repeatable>
-              <modality>Mandatory if</modality>
-              <guideline>Select the primary language spoken in the audio or video
-                            file.
-                            Select the primary
-                            language written on the image or in the document.</guideline>
-              <example>English;Yoruba;Arabic</example>
-            </label>
+              </label>
           </labels>
           <settings>
             <setting name="fieldWidth">40</setting>
@@ -4766,15 +4659,7 @@
                             audio
                             resource). The
                             other language written on the image or in the document. </description>
-              <entry>String-CV (Language)</entry>
-              <dcequivalent>dc:language</dcequivalent>
-              <repeatable>Yes</repeatable>
-              <modality>Optional</modality>
-              <guideline>Select the other language spoken in the audio or video file.
-                            Select the other
-                            language written on the image or in the document.</guideline>
-              <example>English;Yoruba;Arabic</example>
-            </label>
+              </label>
           </labels>
           <settings>
             <setting name="fieldWidth">40</setting>
@@ -4808,15 +4693,7 @@
           <name>Themes</name>
           <description>Descriptive words that are most significant and unique to the
                     resource</description>
-          <entry>String-CV (Themes)</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Strongly Suggested</modality>
-          <guideline>Provide maximum of five most significant and unique words that can
-                    describe the
-                    content of the resource. Separate each word with comma.</guideline>
-          <example>Colonised;Forgotten;Inclusion;Post-conflict;Refugee</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -4842,15 +4719,7 @@
           <name>Keywords</name>
           <description>Descriptive words that are most significant and unique to the
                     resource.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent>dc:subject</dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Strongly Suggested</modality>
-          <guideline>Provide maximum of five most significant and unique words that can
-                    describe the content of the resource. Separate each word with comma.
-                </guideline>
-          <example>Migration;Conflict;Community</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -4878,13 +4747,7 @@
                     not
                     find a
                     metadata field according to your need.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline></guideline>
-          <example></example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -4909,13 +4772,7 @@
         <label locale="en_US">
           <name>Coordinates</name>
           <description>Coordinates of the resources.</description>
-          <entry>Integer</entry>
-          <dcequivalent>dc:coverage</dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>It should be written as [lang,lat]</guideline>
-          <example>[10.77555,106.701944]</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -4940,16 +4797,7 @@
         <label locale="en_US">
           <name>Cultural Group</name>
           <description>The cultural or ethnic group connected to the resource.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Strongly Suggested</modality>
-          <guideline>Provide the names of all the cultural or ethnic group/community
-                    connected
-                    to the
-                    resource. This could be more than one.</guideline>
-          <example>Arabs;Assyrians;Balanta</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -4974,20 +4822,7 @@
         <label locale="en_US">
           <name>Cultural Context</name>
           <description>The cultural event or context associated with the resource. </description>
-          <entry>String-CV (Cultural Context)</entry>
-          <dcequivalent>t</dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Strongly Suggested</modality>
-          <guideline>Describe the cultural context or event associated with the resource.
-                    This
-                    descriptor responds to ‘What was happening when the resource was produced?’,
-                    ‘What event
-                    or practice is the resource recording?’ A list of suggested events is
-                    provided
-                    but add
-                    additional, more specific values to the vocabulary.</guideline>
-          <example>Dancing;Migration;Singing</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -5012,21 +4847,7 @@
         <label locale="en_US">
           <name>Social Group Setting</name>
           <description>The social group associated with or recorded by the resource.</description>
-          <entry>String-CV (Social Group)</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Describe the social group associated with the resource. This
-                    descriptor
-                    responds
-                    to ‘What is the description of the people recorded by the resources?’ A list
-                    of
-                    suggested social group is provided but add additional, more specific values
-                    to
-                    the
-                    vocabulary. e.g. https://simplicable.com/society/social-groups</guideline>
-          <example>Classmates;Family;Committees</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -5051,19 +4872,7 @@
         <label locale="en_US">
           <name>Production Technique</name>
           <description>The defined way adopted to produce the resource.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Describe the technique used in producing the resource. This
-                    descriptor
-                    responds
-                    to ‘How was the resource produced?’ A list of relevant production technique
-                    is
-                    provided
-                    but additional techniques can be added.</guideline>
-          <example>Photography;Report writing;Audio recording;Video recording</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5087,16 +4896,7 @@
         <label locale="en_US">
           <name>Equipment Used</name>
           <description>The equipment used directly for the production of the resource.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>List all the equipment used for the production of the resource.
-                    Provide
-                    the
-                    general names of each equipment, separated with commas.</guideline>
-          <example>Tripod stand;DSLR camera;Video recording</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5121,18 +4921,7 @@
           <name>Dates</name>
           <description>A point or period of time associated with the creation of the
                     resource.</description>
-          <entry>Integer</entry>
-          <dcequivalent>dc:created</dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Strongly Suggested</modality>
-          <guideline>Enter the date the resource was created. Recommended practice is to
-                    express date
-                    using the format YYYY-MM-DD [ISO 8601-1]. If the full date is unknown, month
-                    and
-                    year
-                    (YYYY-MM) or just year (YYYY) may be used.</guideline>
-          <example>2022-01-04 or 2022-01 or 2022</example>
-        </label>
+          </label>
       </labels>
       <elements>
         <metadataElement code="dates_value" datatype="DateRange">
@@ -5185,15 +4974,7 @@
           <description>Information about the shareability, distribution and adaptation of
                     the
                     resource.</description>
-          <entry>String-CV (Licence)</entry>
-          <dcequivalent>dc:licence</dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Mandatory</modality>
-          <guideline>Select which licence is applicable to the resource. Consider this
-                    carefully
-                    before making your selection.</guideline>
-          <example>CC BY-NC 4.0</example>
-        </label>
+          </label>
       </labels>
       <typeRestrictions>
         <restriction>
@@ -5214,13 +4995,7 @@
           <description>A statement about the intellectual property rights (IPR) held in or
                     over a resource, a legal document giving official permission to do something
                     with a resource, or a statement about access rights.</description>
-          <entry>String-CV (Rights Statement)</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Choose a statement from "Rights Statement" list.</guideline>
-          <example>In Copyright - EU Orphan Work (InC-OW-EU)</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -5247,33 +5022,7 @@
           <description>This refers to the attributed standard that governs the content and
                     knowledge of
                     the resources and who can access the resource.</description>
-          <entry>String-CV (Cultural Sensitivity)</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Mandatory</modality>
-          <guideline>Select the level of cultural sensitivity of the content and knowledge
-                    of
-                    the
-                    resource. Consider this carefully before making your selection. ---Highly
-                    sensitive
-                    refers to resource that cannot be viewed, downloaded, print nor accessed.
-                    The
-                    resources
-                    in this category are confidential. The depositor, persons connected to the
-                    project and
-                    repository administrators may have access to the resource. ;Moderately
-                    sensitivy
-                    refers to resources that are to be viewed only, not to be downloaded and
-                    print.
-                    Retrievers interested in accessing the resource need to fill Data Retrieval
-                    Form to
-                    justify the need for the resource. Data Retrieval Form to be assessed and
-                    approved by
-                    the Principal Investigator and co-PIs ;Low sensitivity refers to resources
-                    that are to
-                    be shared openly. Retrievers will be able to view, download, print and use</guideline>
-          <example>Highly sensitive, Medium sensitivity, Low sensitivity</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -5298,21 +5047,7 @@
         <label locale="en_US">
           <name>Access Restriction</name>
           <description>This refers to availability of the resource.</description>
-          <entry>Boolean</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Mandatory if</modality>
-          <guideline>Select the level of access that is appropriate to the resource.
-                    Consider
-                    this
-                    carefully before making your selection. ---Yes refers to resources that
-                    are
-                    restricted. If you choose Yes, you need to justify ;No refers to
-                    resources
-                    with no
-                    access restriction. Resources will be made openly available.</guideline>
-          <example>Yes, No</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -5337,26 +5072,7 @@
         <label locale="en_US">
           <name>Reasons for Restriction</name>
           <description>Justification for limiting access to the resources.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Mandatory if</modality>
-          <guideline>The field is mandatory if the value for ‘Access restriction’ is Yes.
-                    Provide
-                    justifications for limiting the access to the resource and specify the
-                    consequences and
-                    potential impacts of making the resource accessible. Specify if access to
-                    the
-                    resource
-                    should ne restricted permanently or for a specific period of time.</guideline>
-          <example>The image records various civil protests and disobedience is countries
-                    that
-                    are
-                    repressive. Making the image accessible could make the persons connected to
-                    the
-                    image
-                    targets. Therefore, access to the image should be permanently restricted.</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">90</setting>
@@ -5376,7 +5092,7 @@
       </typeRestrictions>
     </metadataElement>
 
-    <!-- Participants -->
+    
 
     <metadataElement code="anonymised" datatype="List" list="access_statuses">
       <labels>
@@ -5384,14 +5100,7 @@
           <name>Anonymised</name>
           <description>Indicate if the ‘Full name’ of the participant has been anonymised
                     using pseudo names.</description>
-          <entry>Boolean</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Mandatory</modality>
-          <guideline>Please state either ‘True’ or ‘False’ to indicate if the
-                    participant’s name has been anonymised.</guideline>
-          <example>True, False</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5416,14 +5125,7 @@
         <label locale="en_US">
           <name>Ethnic Community</name>
           <description>This is the ethnic group which the participant identifies with.</description>
-          <entry>Boolean</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Provide the name of the ethnic group of the participant identifies
-                    with. This is different from nationality.</guideline>
-          <example>Yoruba, Abazins, Albanians</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5448,15 +5150,7 @@
         <label locale="en_US">
           <name>Gender</name>
           <description>The gender that the participant identifies with.</description>
-          <entry>String-CV (Gender)</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Provide the gender of the participant. If the appropriate gender is
-                    not listed, please add it to the vocabulary. If the participant isn't alive
-                    or they don't give that information directly, please use "Unknown" term.</guideline>
-          <example>Male, Female, Non-binary, Prefer not to say, Unknown</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5481,15 +5175,7 @@
         <label locale="en_US">
           <name>Occupation</name>
           <description>The main economic work or activity of the participant.</description>
-          <entry>String-CV (Occupation)</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Provide the main occupation of the participant with which the
-                    participant earns a living. If the participant is anonymised, pick
-                    ‘Unknown’.</guideline>
-          <example>Student, Architect, Conservator</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5515,17 +5201,7 @@
           <name>Participant Role</name>
           <description>The main contributing role played by the participant in the context
                     of the project.</description>
-          <entry>String-CV (Role)</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Mandatory</modality>
-          <guideline>Choose from the list, a role that is the nearest to the description
-                    of you involvement in the project. If the list does not contain a suitable
-                    descriptor, you can add additional roles. The listed roles are meant to
-                    broadly categorise participants and their contributions to the project.</guideline>
-          <example>Project leader, Collector, Monitor, Contributor, Administrator, Guest,
-                    Researcher</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5607,13 +5283,7 @@
         <label locale="en_US">
           <name>Affiliation</name>
           <description>The affiliation of the participant including institution, organisation etc the lead project investigator works for.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Provide the affiliation and country of the lead project investigator. If self-employed, enter the name of your organisation.</guideline>
-          <example>School of Archaeology and Heritage Studies, University of Ghana</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5638,13 +5308,7 @@
         <label locale="en_US">
           <name>Biographical History</name>
           <description>Information relevant to the understanding of the life, activities, and relationships of the person.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline></guideline>
-          <example></example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5669,13 +5333,7 @@
         <label locale="en_US">
           <name>Other Significant Information</name>
           <description>Any other important information not recorded elsewhere in the biographical history.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline></guideline>
-          <example></example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5700,13 +5358,7 @@
         <label locale="en_US">
           <name>Authority Sources</name>
           <description>Link to participants record on VIAF, IF website, ORCID, Wikidata.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline></guideline>
-          <example></example>
-        </label>
+          </label>
       </labels>
       <elements>
         <metadataElement code="authurl" datatype="Url">
@@ -5746,20 +5398,14 @@
       </typeRestrictions>
     </metadataElement>
 
-    <!-- Projects -->
+    
 
     <metadataElement code="prjtype" datatype="List" list="prjtypelist">
       <labels>
         <label locale="en_US">
           <name>Project Type</name>
           <description>The name of the Imagining Futures Project Type.</description>
-          <entry>String-CV (Project types)</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Provide the IF project type information. Choose between from the list.</guideline>
-          <example>Start Up Projects (2020-2021)</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5784,13 +5430,7 @@
         <label locale="en_US">
           <name>Project Region</name>
           <description>The name of the Imagining Futures Project Regions.</description>
-          <entry>String-CV (Project types)</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>Yes</repeatable>
-          <modality>Optional</modality>
-          <guideline>Provide the IF project region information. Choose between from the list.</guideline>
-          <example>North America</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5815,13 +5455,7 @@
         <label locale="en_US">
           <name>IF Webpage</name>
           <description>A link to the project's Imagining Futures website.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>No</repeatable>
-          <modality>Strongly Suggested</modality>
-          <guideline>Provide the URL of the project's IF webpage.</guideline>
-          <example>https://imaginingfutures.world/projects/in-search-of-la/</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5846,13 +5480,7 @@
         <label locale="en_US">
           <name>External Website</name>
           <description>A link to the project's alternative website.</description>
-          <entry>String-Free text</entry>
-          <dcequivalent></dcequivalent>
-          <repeatable>No</repeatable>
-          <modality>Optional</modality>
-          <guideline>Provide the URL of the project'ss external webpage.</guideline>
-          <example>https://phi.history.ucla.edu/la-storymap/</example>
-        </label>
+          </label>
       </labels>
       <settings>
         <setting name="fieldWidth">30</setting>
@@ -5872,15 +5500,15 @@
       </typeRestrictions>
     </metadataElement>
 
-    <!-- Places -->
+    
 
-    <!-- Controlled Vocabularies -->
+    
   </elementSets>
 
 
   <userInterfaces>
 
-  <!-- Objects-->
+  
 
     <userInterface code="objects_ui" type="ca_objects">
       <labels>
@@ -6063,7 +5691,7 @@
       </screens>
     </userInterface>
 
-    <!-- Entities-->
+    
 
     <userInterface code="entities_ui" type="ca_entities">
       <labels>
@@ -6169,7 +5797,7 @@
       </screens>
     </userInterface>
 
-    <!-- Collections-->
+    
 
     <userInterface code="collections_ui" type="ca_collections">
       <labels>
@@ -6262,7 +5890,7 @@
       </screens>
     </userInterface>
 
-    <!-- Places -->
+    
 
     <userInterface code="places_ui" type="ca_places">
       <labels>
@@ -6332,7 +5960,7 @@
       </screens>
     </userInterface>
 
-    <!-- Occurrences (Themes Test)-->
+    
 
     <userInterface code="occurrences_ui" type="ca_occurrences">
       <labels>
@@ -6486,7 +6114,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="rightsholder" default="1">
           <labels>
@@ -6496,7 +6124,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="creator" default="1">
           <labels>
@@ -6506,7 +6134,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="contributor" default="1">
           <labels>
@@ -6516,7 +6144,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="curator" default="0">
           <labels>
@@ -6530,7 +6158,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="moderator" default="0">
           <labels>
@@ -6544,7 +6172,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="speaker" default="0">
           <labels>
@@ -6558,7 +6186,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="panelist" default="0">
           <labels>
@@ -6572,7 +6200,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="documentarian" default="0">
           <labels>
@@ -6586,7 +6214,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="architect" default="0">
           <labels>
@@ -6600,7 +6228,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="designer" default="0">
           <labels>
@@ -6614,7 +6242,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="author" default="0">
           <labels>
@@ -6628,7 +6256,7 @@
             </label>
           </labels>
           <subTypeLeft>interview</subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="performer" default="0">
           <labels>
@@ -6642,7 +6270,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="staff_member" default="0">
           <labels>
@@ -6656,7 +6284,7 @@
             </label>
           </labels>
           <subTypeLeft>interview</subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="consultant" default="0">
           <labels>
@@ -6670,7 +6298,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="publisher" default="0">
           <labels>
@@ -6684,7 +6312,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="sponsor" default="0">
           <labels>
@@ -6698,7 +6326,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="partner_museum" default="0">
           <labels>
@@ -6712,7 +6340,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -6730,7 +6358,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -6748,7 +6376,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="located" default="0">
           <labels>
@@ -6762,7 +6390,7 @@
             </label>
           </labels>
           <subTypeLeft>image</subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="depicts" default="1">
           <labels>
@@ -6776,7 +6404,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="describes" default="0">
           <labels>
@@ -6790,7 +6418,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -6808,7 +6436,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="used" default="0">
           <labels>
@@ -6822,7 +6450,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="describes" default="0">
           <labels>
@@ -6836,7 +6464,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -6854,7 +6482,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="similar" default="0">
           <labels>
@@ -6868,7 +6496,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="duplicate" default="0">
           <labels>
@@ -6882,7 +6510,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="part_of" default="0">
           <labels>
@@ -6896,7 +6524,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -6914,7 +6542,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="depicts" default="0">
           <labels>
@@ -6928,7 +6556,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -6946,7 +6574,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="child" default="1">
           <labels>
@@ -6992,7 +6620,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="residence" default="0">
           <labels>
@@ -7006,7 +6634,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="workplace" default="0">
           <labels>
@@ -7020,7 +6648,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="ownership" default="0">
           <labels>
@@ -7034,7 +6662,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="built_by" default="0">
           <labels>
@@ -7048,7 +6676,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7066,7 +6694,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="curator" default="0">
           <labels>
@@ -7080,7 +6708,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="moderator" default="0">
           <labels>
@@ -7094,7 +6722,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="panelist" default="0">
           <labels>
@@ -7108,7 +6736,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="speaker" default="0">
           <labels>
@@ -7122,7 +6750,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="documentarian" default="0">
           <labels>
@@ -7136,7 +6764,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="architect" default="0">
           <labels>
@@ -7150,7 +6778,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="designer" default="0">
           <labels>
@@ -7164,7 +6792,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="author" default="0">
           <labels>
@@ -7178,7 +6806,7 @@
             </label>
           </labels>
           <subTypeLeft>interview</subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="performer" default="0">
           <labels>
@@ -7192,7 +6820,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="staff_member" default="0">
           <labels>
@@ -7206,7 +6834,7 @@
             </label>
           </labels>
           <subTypeLeft>interview</subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="consultant" default="0">
           <labels>
@@ -7220,7 +6848,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="publisher" default="0">
           <labels>
@@ -7234,7 +6862,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="sponsor" default="0">
           <labels>
@@ -7248,7 +6876,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="partner_museum" default="0">
           <labels>
@@ -7262,7 +6890,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7280,7 +6908,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="provider" default="0">
           <labels>
@@ -7294,7 +6922,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7312,7 +6940,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7330,7 +6958,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7348,7 +6976,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7366,7 +6994,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7384,7 +7012,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7420,7 +7048,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7438,7 +7066,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7474,7 +7102,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7492,7 +7120,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7510,7 +7138,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7528,7 +7156,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7546,7 +7174,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="illustrated" default="1">
           <labels>
@@ -7560,7 +7188,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7578,7 +7206,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="describes" default="1">
           <labels>
@@ -7592,7 +7220,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7610,7 +7238,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
         <type code="describes" default="1">
           <labels>
@@ -7624,7 +7252,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>
@@ -7674,7 +7302,7 @@
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>
-          <subTypeRight></subTypeRight>
+          <subTypeRight />
         </type>
       </types>
     </relationshipTable>

--- a/runValidator.sh
+++ b/runValidator.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Check if Python is installed
-if ! [ -x "$(command -v python)" ]; then
-  echo 'Error: Python is not installed.' >&2
+if ! [ -x "$(command -v python3)" ]; then
+  echo 'Error: Python3 is not installed.' >&2
   exit 1
 fi
 
@@ -20,8 +20,8 @@ if [ ! -d "$validator_dir" ]; then
 fi
 
 requirements="$validator_dir/requirements.txt"
-python -m pip install -r "$requirements"
+python3 -m pip install -r "$requirements"
 
 validator_script="$validator_dir/validatexml-xsd.py"
 
-python "$validator_script" "$@"
+python3 "$validator_script" "$@"


### PR DESCRIPTION
### Added

- Added settings features (`usewysiwygeditor`, `fieldWidth` and `fieldHeight`) to `metadataElement code="description"`.
- Included a validator for XML against the XSD schema. Validator can be run with the help of `runValidator.bat` (Windows) or `runValidator.sh` (Linux/MacOS) scripts.

### Changed

- Adjust XSD schema to match the new metadataElement structure.

### Removed

- Removed tags `entry`, `dcequivalent`, `repeatable`, `modality`, `guideline`, and `example` from `metadataElement/labels/label`.
